### PR TITLE
Move test deps to test profile

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,10 +4,12 @@
  , warnings_as_errors
  ]}.
 
-{deps,
-  [ {meck,   {git,"git@github.com:kivra/meck.git",   {tag, "0.8.8"}}}
-  , {proper, {git,"git@github.com:kivra/proper.git", {tag, "v1.2"}}}
-  ]}.
+{deps,[]}.
+
+{profiles, [{test, [{deps, [ {meck,      {git, "git@github.com:kivra/meck.git"     , {tag,    "0.8.8"}}}
+                           , {proper,    {git, "git@github.com:kivra/proper.git"   , {tag, "v1.2"}}}
+                           ]}]}]}.
+
 
 {xref_checks, [ deprecated_function_calls
               , deprecated_functions

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,1 @@
-[{<<"meck">>,
-  {git,"git@github.com:kivra/meck.git",
-       {ref,"1dd41ae9e6364c802cbc0b7fd75f27492ae76d80"}},
-  0},
- {<<"proper">>,
-  {git,"git@github.com:kivra/proper.git",
-       {ref,"5f0d69c831b6c9f52535c3d1846efca480f6190d"}},
-  0}].
+[].


### PR DESCRIPTION
Move test dependencies to test profile so projects that include money_laundry are not bound to use version v1.2 of proper.